### PR TITLE
Update sharp version

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "logagent-js": "^1.2.39",
     "npm": "^6.8.0",
     "plist": "^2.0.1",
-    "sharp": "^0.16.2",
+    "sharp": "^0.22.1",
     "tempfile": "^1.1.1"
   },
   "engines": {


### PR DESCRIPTION
The dependency, "sharp" is having [issue](https://github.com/lovell/sharp/issues/1668) installing on Node 12 on Windows,

This fixes the dependency version so it can be installed without any issues.

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>