### PR TITLE
Add diagnostics

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,6 +82,27 @@ class iDeviceClient extends EventEmitter {
         });
     }
 
+    diagnostics(serial, option) {
+        if (!_checkSerial(serial)) return Promise.reject('invalid serial number');
+        let defaultOption = {
+            'command': 'diagnostics',
+            'key': 'All',
+        };
+        defaultOption = extend(true, defaultOption, option);
+        let cmd = 'idevicediagnostics -u ' + serial + ' ' + defaultOption['command'];
+        if (('key' in defaultOption) && (defaultOption['key'])) {
+            cmd += ' ' + defaultOption['key'];
+        }
+        return exec(cmd).then((stdout) => {
+            try {
+                let result = plist.parse(stdout);
+                return result;
+            } catch (e) {
+                throw e;
+            }
+        });
+    }
+
     screencap(serial, option) {
         if (!_checkSerial(serial)) return Promise.reject('invalid serial number');
         let defaultOption = {


### PR DESCRIPTION
Added feature to run `idevicediagnostics`, helpful to calculate Battery Health:

```js
const { NominalChargeCapacity, DesignCapacity } = (await idevicekit.diagnostics(udid, { command: 'ioregentry', key: 'AppleSmartBattery' })).IORegistry;
const BatteryHealth = NominalChargeCapacity < DesignCapacity ? Math.round(100 * NominalChargeCapacity / DesignCapacity) : 100
```

Signed-off-by: Ali Yousuf <aly.yousuf7@gmail.com>